### PR TITLE
Update VPAID getAdRemainingTime

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
-    "babel-istanbul": "^0.11.0",
+    "babel-istanbul": "^0.12.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.18.0",
     "babelify": "^7.3.0",


### PR DESCRIPTION
I believe getAdRemainingTime and getAdDuration are incorrectly returning -2 when we know what the value should be.

The ad being engaged should not affect the duration OR the remaining time.

I believe we need to change the logic so that:

- getAdRemainingTime only returns -2 if we do not know the video slot duration or the video slot current time
- getAdDuration only returns -2 if we do not know the video slot duration.