### PR TITLE
Swapped order of 2 lines in video-tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vpaid-ad",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "VPAID ad class for extending purposes.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/video-tracker.js
+++ b/src/video-tracker.js
@@ -21,8 +21,8 @@ function handleTimeupdate () {
   const upcomingQuartileIndex = this.quartileIndexEmitted + 1
   const upcomingQuartile = quartiles[upcomingQuartileIndex]
   if (upcomingQuartile && this.el.currentTime / this.el.duration > upcomingQuartile.value) {
-    this.emit(upcomingQuartile.name)
     this.quartileIndexEmitted = upcomingQuartileIndex
+    this.emit(upcomingQuartile.name)
   }
 }
 


### PR DESCRIPTION
Ad video quartile events were being emitted twice on mobile.